### PR TITLE
Added SeparationType enum to model molecule separations. 

### DIFF
--- a/msdk-data/src/main/java/io/github/msdk/datamodel/impl/MSDKObjectBuilder.java
+++ b/msdk-data/src/main/java/io/github/msdk/datamodel/impl/MSDKObjectBuilder.java
@@ -11,13 +11,13 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
-
 package io.github.msdk.datamodel.impl;
 
 import io.github.msdk.datamodel.rawdata.ChromatographyInfo;
 import io.github.msdk.datamodel.rawdata.DataPoint;
 import io.github.msdk.datamodel.rawdata.MsScan;
 import io.github.msdk.datamodel.rawdata.RawDataFile;
+import io.github.msdk.datamodel.rawdata.SeparationType;
 
 import javax.annotation.Nonnull;
 
@@ -27,20 +27,38 @@ import javax.annotation.Nonnull;
 public class MSDKObjectBuilder {
 
     public static final @Nonnull DataPoint getDataPoint(double mz,
-	    float intensity) {
-	return new SimpleDataPoint(mz, intensity);
+            float intensity) {
+        return new SimpleDataPoint(mz, intensity);
     }
 
     public static final @Nonnull RawDataFile getRawDataFile() {
-	return new SimpleRawDataFile();
+        return new SimpleRawDataFile();
     }
 
     public static final @Nonnull MsScan getMsScan(@Nonnull RawDataFile dataFile) {
-	return new SimpleMsScan(dataFile);
+        return new SimpleMsScan(dataFile);
     }
 
-    public static final @Nonnull ChromatographyInfo getChromatographyData() {
-	return new SimpleChromatographyData();
+    public static final @Nonnull ChromatographyInfo getChromatographyInfo1D(SeparationType separationType, float rt1) {
+        return new SimpleChromatographyInfo(rt1, null, null, separationType);
+    }
+
+    public static final @Nonnull ChromatographyInfo getChromatographyInfo2D(SeparationType separationType, float rt1, float rt2) {
+        if (separationType.getFeatureDimensions() < 2) {
+            throw new IllegalArgumentException("2D ChromatographyInfo requires at least 2 feature dimensions. Provided separation type " + separationType + " has " + separationType.getFeatureDimensions());
+        }
+        //TODO add further validation
+        return new SimpleChromatographyInfo(rt1, rt2, null, separationType);
+    }
+
+    public static final @Nonnull ChromatographyInfo getImsInfo(SeparationType separationType, float rt1, float ionDriftTime) {
+        if (separationType.getFeatureDimensions() < 2) {
+            throw new IllegalArgumentException("2D ChromatographyInfo requires at least 2 feature dimensions. Provided separation type " + separationType + " has " + separationType.getFeatureDimensions());
+        }
+        if(separationType!=SeparationType.IMS) {
+            throw new IllegalArgumentException("2D ChromatographyInfo for IMS separation requires IMS separation type. Provided separation type "+separationType);
+        }
+        return new SimpleChromatographyInfo(rt1, null, ionDriftTime, separationType);
     }
 
 }

--- a/msdk-data/src/main/java/io/github/msdk/datamodel/impl/SimpleChromatographyInfo.java
+++ b/msdk-data/src/main/java/io/github/msdk/datamodel/impl/SimpleChromatographyInfo.java
@@ -15,10 +15,20 @@
 package io.github.msdk.datamodel.impl;
 
 import io.github.msdk.datamodel.rawdata.ChromatographyInfo;
+import io.github.msdk.datamodel.rawdata.SeparationType;
 
-public class SimpleChromatographyData implements ChromatographyInfo {
+public class SimpleChromatographyInfo implements ChromatographyInfo {
 
     private Float retentionTime, secondaryRetentionTime, ionDriftTime;
+    
+    private SeparationType separationType;
+
+    SimpleChromatographyInfo(Float retentionTime, Float secondaryRetentionTime, Float ionDriftTime, SeparationType separationType) {
+        this.retentionTime = retentionTime;
+        this.secondaryRetentionTime = secondaryRetentionTime;
+        this.ionDriftTime = ionDriftTime;
+        this.separationType = separationType;
+    }
 
     /**
      * @return the retentionTime
@@ -48,6 +58,11 @@ public class SimpleChromatographyData implements ChromatographyInfo {
     public int compareTo(ChromatographyInfo o) {
 	// TODO Auto-generated method stub
 	return 0;
+    }
+
+    @Override
+    public SeparationType getSeparationType() {
+        return separationType;
     }
 
 }

--- a/msdk-interfaces/src/main/java/io/github/msdk/datamodel/rawdata/ChromatographyInfo.java
+++ b/msdk-interfaces/src/main/java/io/github/msdk/datamodel/rawdata/ChromatographyInfo.java
@@ -55,5 +55,11 @@ public interface ChromatographyInfo extends Comparable<ChromatographyInfo> {
      */
     @Nullable
     Float getIonDriftTime();
+    
+    /**
+     * Returns the separation type used for separation of molecules.
+     * @return the seperation type. Returns {@link SeparationType#UNKNOWN} for unknown separations.
+     */
+    SeparationType getSeparationType();
 
 }

--- a/msdk-interfaces/src/main/java/io/github/msdk/datamodel/rawdata/SeparationType.java
+++ b/msdk-interfaces/src/main/java/io/github/msdk/datamodel/rawdata/SeparationType.java
@@ -1,0 +1,83 @@
+/* 
+ * (C) Copyright 2015 by MSDK Development Team
+ *
+ * This software is dual-licensed under either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package io.github.msdk.datamodel.rawdata;
+
+/**
+ *
+ * Enum for different separation technologies used as a preprocessing step
+ * before the actual data point acquisition.
+ * <p>
+ * A separation type will usually provide additional information for acquired
+ * {@link MsScan} objects. The most common case being a chromatographic
+ * separation coupled to a mass spectrometer. Here, the chromatograph would
+ * provide the retention time of each acquired data point as additional
+ * information.
+ *
+ */
+public enum SeparationType {
+
+    /**
+     * Gas chromatography.
+     */
+    GC(1),
+    /**
+     * Comprehensive two-dimensional liquid chromatography.
+     */
+    GCxGC(2),
+    /**
+     * Liquid chromatography.
+     */
+    LC(1),
+    /**
+     * Comprehensive two-dimensional liquid chromatography.
+     */
+    LCxLC(2),
+    /**
+     * Capillary electrophoresis chromatography.
+     */
+    CE(1),
+    /**
+     * Ion mobility spectrometry. First dimension is retention time, second
+     * dimension is ion drift time.
+     */
+    IMS(2),
+    /**
+     * Unknown separation method. Expect 1 feature dimension, e.g. retention
+     * time.
+     */
+    UNKNOWN(1);
+
+    private final int featureDimensions;
+
+    private SeparationType(int separationDimensions) {
+        this.featureDimensions = separationDimensions;
+    }
+
+    /**
+     * Return the number of additional features linked to an {@link MsScan} and
+     * to {@link ChromatographyInfo}.
+     * <p>
+     * For chromatography, the number will be 1 for one-dimensional
+     * chromatography, where each data point has a retention time assigned to
+     * it.
+     * <p>
+     * The number will be 2 for (comprehensive) two-dimensional chromatography,
+     * where each data point has two retention times assigned to it.
+     *
+     * @return the number of feature dimensions.
+     */
+    public int getFeatureDimensions() {
+        return this.featureDimensions;
+    }
+}

--- a/msdk-io/src/main/java/io/github/msdk/io/rawdataimport/netcdf/NetCDFFileImportAlgorithm.java
+++ b/msdk-io/src/main/java/io/github/msdk/io/rawdataimport/netcdf/NetCDFFileImportAlgorithm.java
@@ -22,6 +22,7 @@ import io.github.msdk.datamodel.rawdata.DataPoint;
 import io.github.msdk.datamodel.rawdata.MassSpectrumType;
 import io.github.msdk.datamodel.rawdata.MsScan;
 import io.github.msdk.datamodel.rawdata.RawDataFile;
+import io.github.msdk.datamodel.rawdata.SeparationType;
 import io.github.msdk.io.spectrumtypedetection.SpectrumTypeDetectionAlgorithm;
 
 import java.io.File;
@@ -402,10 +403,10 @@ public class NetCDFFileImportAlgorithm implements MSDKMethod<RawDataFile> {
 	MassSpectrumType spectrumType = detector.getResult();
 	scan.setSpectrumType(spectrumType);
 
+        //TODO set correct separation type from global netCDF file attributes
 	ChromatographyInfo chromData = MSDKObjectBuilder
-		.getChromatographyData();
-	// chromData.setRetentionTime(retentionTime);
-
+		.getChromatographyInfo1D(SeparationType.GC, retentionTime.floatValue());
+        scan.setChromatographyInfo(chromData);
 	return scan;
 
     }

--- a/msdk-io/src/main/java/io/github/msdk/io/rawdataimport/xmlformats/XMLFileImportAlgorithm.java
+++ b/msdk-io/src/main/java/io/github/msdk/io/rawdataimport/xmlformats/XMLFileImportAlgorithm.java
@@ -23,6 +23,7 @@ import io.github.msdk.datamodel.rawdata.MassSpectrumType;
 import io.github.msdk.datamodel.rawdata.MsScan;
 import io.github.msdk.datamodel.rawdata.RawDataFile;
 import io.github.msdk.datamodel.rawdata.RawDataFileType;
+import io.github.msdk.datamodel.rawdata.SeparationType;
 import io.github.msdk.io.spectrumtypedetection.SpectrumTypeDetectionAlgorithm;
 import io.github.msdk.util.DataPointSorter;
 import io.github.msdk.util.SortingDirection;
@@ -227,9 +228,9 @@ public class XMLFileImportAlgorithm implements MSDKMethod<RawDataFile> {
 		} else {
 		    retentionTime = Double.parseDouble(value) / 60d;
 		}
+                //TODO Update with specific code for separation method
 		final ChromatographyInfo newChromData = MSDKObjectBuilder
-			.getChromatographyData();
-		// newChromData.setRetentionTime(retentionTime);
+			.getChromatographyInfo1D(SeparationType.GC, (float)retentionTime);
 		return newChromData;
 
 	    }


### PR DESCRIPTION
.Added specific MSDKObjectBuilder methods to create Chromatography Info objects. Updated NetCDFFileImportAlgorithm and XMLFileImportAlgorithm to use the new methods. Renamed SimpleChromatographyData to SimpleChromatographyInfo to conform with interface naming.