### PR TITLE
MzTabFileImportMethod: check if MZTabFile is null

### DIFF
--- a/msdk-io/msdk-io-mztab/src/main/java/io/github/msdk/io/mztab/MzTabFileExportMethod.java
+++ b/msdk-io/msdk-io-mztab/src/main/java/io/github/msdk/io/mztab/MzTabFileExportMethod.java
@@ -150,8 +150,8 @@ public class MzTabFileExportMethod implements MSDKMethod<File> {
         mtd.addVariableModParam(1, new CVParam("MS", "MS:1002454",
                 "No variable modifications searched", null));
 
-        // Create stable columns - only available in jmztab 3.0.2
-        // factory.addDefaultStableColumns(); 
+        // Create stable columns - only available in jmztab 3.0.2 and later
+        factory.addDefaultStableColumns();
 
         // Add optional columns which have stable order
         factory.addURIOptionalColumn();

--- a/msdk-io/msdk-io-mztab/src/main/java/io/github/msdk/io/mztab/MzTabFileImportMethod.java
+++ b/msdk-io/msdk-io-mztab/src/main/java/io/github/msdk/io/mztab/MzTabFileImportMethod.java
@@ -122,6 +122,10 @@ public class MzTabFileImportMethod implements MSDKMethod<FeatureTable> {
 
             MZTabFile mzTabFile = mzTabFileParser.getMZTabFile();
 
+            if (mzTabFile == null) {
+                return null;
+            }
+
             // Let's say the initial parsing took 10% of the time
             totalRows = mzTabFile.getSmallMolecules().size();
             samples = mzTabFile.getMetadata().getMsRunMap().size();


### PR DESCRIPTION
This fixes the ```NullPointerException``` error in ```MzTabFileExportMethodTest``` (see https://travis-ci.org/msdk/msdk/builds/150175189#L6132), although the test now fails instead. So far, I have been unable to track down that problem which I assume is in ```MzTabFileExportMethod```.

