### PR TITLE
Support different MzTolerances for each scan in the chromatogram builder

### DIFF
--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantDaTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantDaTolerance.java
@@ -14,11 +14,13 @@
 
 package io.github.msdk.util.tolerances;
 
+import io.github.msdk.datamodel.rawdata.MsScan;
+
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.Range;
 
-public class ConstantDaTolerance implements MzTolerance {
+public class ConstantDaTolerance implements MzTolerance, MzToleranceProvider {
 
     private final @Nonnull Double mzTolerance;
 
@@ -63,5 +65,10 @@ public class ConstantDaTolerance implements MzTolerance {
     @Override
     public String toString() {
         return mzTolerance + " Da";
+    }
+
+    @Override
+    public MzTolerance getMzTolerance(MsScan scan) {
+        return this;
     }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantDaTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantDaTolerance.java
@@ -14,13 +14,11 @@
 
 package io.github.msdk.util.tolerances;
 
-import io.github.msdk.datamodel.rawdata.MsScan;
-
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.Range;
 
-public class ConstantDaTolerance implements MzTolerance, MzToleranceProvider {
+public class ConstantDaTolerance implements MzTolerance {
 
     private final @Nonnull Double mzTolerance;
 
@@ -67,8 +65,4 @@ public class ConstantDaTolerance implements MzTolerance, MzToleranceProvider {
         return mzTolerance + " Da";
     }
 
-    @Override
-    public MzTolerance getMzTolerance(MsScan scan) {
-        return this;
-    }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantMzToleranceProvider.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantMzToleranceProvider.java
@@ -1,0 +1,35 @@
+/* 
+ * (C) Copyright 2015-2016 by MSDK Development Team
+ *
+ * This software is dual-licensed under either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+
+package io.github.msdk.util.tolerances;
+
+import io.github.msdk.datamodel.rawdata.MsScan;
+
+/**
+ * This class provides a MzTolerance that is constant for every MsScan.
+ */
+public class ConstantMzToleranceProvider implements MzToleranceProvider {
+
+    private final MzTolerance mzTolerance;
+
+    public ConstantMzToleranceProvider(MzTolerance mzTolerance) {
+        this.mzTolerance = mzTolerance;
+    }
+
+    @Override
+    public MzTolerance getMzTolerance(MsScan scan) {
+        return mzTolerance;
+    }
+
+}

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantPpmTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantPpmTolerance.java
@@ -14,11 +14,13 @@
 
 package io.github.msdk.util.tolerances;
 
+import io.github.msdk.datamodel.rawdata.MsScan;
+
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.Range;
 
-public class ConstantPpmTolerance implements MzTolerance {
+public class ConstantPpmTolerance implements MzTolerance, MzToleranceProvider {
 
     // PPM conversion factor.
     private static final Double MILLION = 1_000_000.0;
@@ -69,5 +71,10 @@ public class ConstantPpmTolerance implements MzTolerance {
     @Override
     public String toString() {
         return ppmTolerance + " ppm";
+    }
+
+    @Override
+    public MzTolerance getMzTolerance(MsScan scan) {
+        return this;
     }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantPpmTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/ConstantPpmTolerance.java
@@ -14,13 +14,11 @@
 
 package io.github.msdk.util.tolerances;
 
-import io.github.msdk.datamodel.rawdata.MsScan;
-
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.Range;
 
-public class ConstantPpmTolerance implements MzTolerance, MzToleranceProvider {
+public class ConstantPpmTolerance implements MzTolerance {
 
     // PPM conversion factor.
     private static final Double MILLION = 1_000_000.0;
@@ -73,8 +71,4 @@ public class ConstantPpmTolerance implements MzTolerance, MzToleranceProvider {
         return ppmTolerance + " ppm";
     }
 
-    @Override
-    public MzTolerance getMzTolerance(MsScan scan) {
-        return this;
-    }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MaximumMzTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MaximumMzTolerance.java
@@ -14,8 +14,6 @@
 
 package io.github.msdk.util.tolerances;
 
-import io.github.msdk.datamodel.rawdata.MsScan;
-
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -27,7 +25,7 @@ import com.google.common.collect.Range;
  * of the absolute and relative values.
  */
 @Immutable
-public class MaximumMzTolerance implements MzTolerance, MzToleranceProvider {
+public class MaximumMzTolerance implements MzTolerance {
 
     // PPM conversion factor.
     private static final Double MILLION = 1000000.0;
@@ -98,8 +96,4 @@ public class MaximumMzTolerance implements MzTolerance, MzToleranceProvider {
         return mzTolerance + " m/z or " + ppmTolerance + " ppm";
     }
 
-    @Override
-    public MzTolerance getMzTolerance(MsScan scan) {
-        return this;
-    }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MaximumMzTolerance.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MaximumMzTolerance.java
@@ -14,6 +14,8 @@
 
 package io.github.msdk.util.tolerances;
 
+import io.github.msdk.datamodel.rawdata.MsScan;
+
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -25,7 +27,7 @@ import com.google.common.collect.Range;
  * of the absolute and relative values.
  */
 @Immutable
-public class MaximumMzTolerance implements MzTolerance {
+public class MaximumMzTolerance implements MzTolerance, MzToleranceProvider {
 
     // PPM conversion factor.
     private static final Double MILLION = 1000000.0;
@@ -94,5 +96,10 @@ public class MaximumMzTolerance implements MzTolerance {
     @Override
     public String toString() {
         return mzTolerance + " m/z or " + ppmTolerance + " ppm";
+    }
+
+    @Override
+    public MzTolerance getMzTolerance(MsScan scan) {
+        return this;
     }
 }

--- a/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MzToleranceProvider.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/util/tolerances/MzToleranceProvider.java
@@ -1,0 +1,32 @@
+/* 
+ * (C) Copyright 2015-2016 by MSDK Development Team
+ *
+ * This software is dual-licensed under either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+
+package io.github.msdk.util.tolerances;
+
+import io.github.msdk.datamodel.rawdata.MsScan;
+
+public interface MzToleranceProvider {
+
+    /**
+     * <p>
+     * Get a {@link io.github.msdk.util.tolerance.MzTolerance} for a given scan.
+     * </p>
+     *
+     * @param MsScan
+     *            an object that implements the
+     *            {@link io.github.msdk.datamodel.rawdata.MsScan} interface.
+     * @return A MzTolerance object.
+     */
+    MzTolerance getMzTolerance(MsScan scan);
+}

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
@@ -87,6 +87,40 @@ public class ChromatogramBuilderMethod
 
     /**
      * <p>
+     * Constructor for ChromatogramBuilderMethod. This version uses the same
+     * MzTolerance for every scan.
+     * </p>
+     *
+     * @param dataPointStore
+     *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
+     *            object.
+     * @param inputFile
+     *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+     * @param inputScans
+     *            a {@link java.util.List} object.
+     * @param minimumTimeSpan
+     *            a {@link java.lang.Double} object.
+     * @param minimumHeight
+     *            a {@link java.lang.Double} object.
+     * @param mzTolerance
+     *            an object that implements the
+     *            {@link io.github.msdk.util.tolerances.MZTolerance}
+     *            interface.
+     * @param noiseLevel
+     *            a {@link java.lang.Float} object.
+     */
+    public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
+            @Nonnull RawDataFile inputFile, @Nonnull List<MsScan> inputScans,
+            @Nonnull Double noiseLevel, @Nonnull Double minimumTimeSpan,
+            @Nonnull Double minimumHeight,
+            @Nonnull MzTolerance mzTolerance) {
+        this(dataPointStore, inputFile, inputFile.getScans(), noiseLevel,
+                minimumTimeSpan, minimumHeight,
+                new ConstantMzToleranceProvider(mzTolerance));
+    }
+
+    /**
+     * <p>
      * Constructor for ChromatogramBuilderMethod.
      * </p>
      *

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
@@ -149,14 +149,14 @@ public class ChromatogramBuilderMethod
         }
 
         HighestDataPointConnector massConnector = new HighestDataPointConnector(
-                noiseLevel, minimumTimeSpan, minimumHeight, mzTolerance);
+                noiseLevel, minimumTimeSpan, minimumHeight);
 
         for (MsScan scan : inputScans) {
 
             if (canceled)
                 return null;
 
-            massConnector.addScan(inputFile, scan);
+            massConnector.addScan(inputFile, scan, mzTolerance);
             processedScans++;
         }
 

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
@@ -30,6 +30,7 @@ import io.github.msdk.datamodel.datastore.DataPointStore;
 import io.github.msdk.datamodel.rawdata.ChromatographyInfo;
 import io.github.msdk.datamodel.rawdata.MsScan;
 import io.github.msdk.datamodel.rawdata.RawDataFile;
+import io.github.msdk.util.tolerances.ConstantMzToleranceProvider;
 import io.github.msdk.util.tolerances.MzTolerance;
 import io.github.msdk.util.tolerances.MzToleranceProvider;
 
@@ -55,70 +56,71 @@ public class ChromatogramBuilderMethod
     private List<Chromatogram> result;
 
     /**
-	 * <p>
-	 * Constructor for ChromatogramBuilderMethod.
-	 * </p>
-	 *
-	 * @param dataPointStore
-	 *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
-	 *            object.
-	 * @param inputFile
-	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
-	 * @param minimumTimeSpan
-	 *            a {@link java.lang.Double} object.
-	 * @param minimumHeight
-	 *            a {@link java.lang.Double} object.
-	 * @param mzToleranceProvider
-	 *            an object that implements the
-	 *            {@link io.github.msdk.util.tolerances.MZToleranceProvider}
-	 *            interface.
-	 * @param noiseLevel
-	 *            a {@link java.lang.Float} object.
-	 */
+     * <p>
+     * Constructor for ChromatogramBuilderMethod. This version uses the same
+     * MzTolerance for every scan.
+     * </p>
+     *
+     * @param dataPointStore
+     *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
+     *            object.
+     * @param inputFile
+     *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+     * @param minimumTimeSpan
+     *            a {@link java.lang.Double} object.
+     * @param minimumHeight
+     *            a {@link java.lang.Double} object.
+     * @param mzTolerance
+     *            an object that implements the
+     *            {@link io.github.msdk.util.tolerances.MZTolerance} interface.
+     * @param noiseLevel
+     *            a {@link java.lang.Float} object.
+     */
     public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
             @Nonnull RawDataFile inputFile, @Nonnull Double noiseLevel,
             @Nonnull Double minimumTimeSpan, @Nonnull Double minimumHeight,
-            @Nonnull MzToleranceProvider mzToleranceProvider) {
+            @Nonnull MzTolerance mzTolerance) {
         this(dataPointStore, inputFile, inputFile.getScans(), noiseLevel,
-                minimumTimeSpan, minimumHeight, mzToleranceProvider);
+                minimumTimeSpan, minimumHeight,
+                new ConstantMzToleranceProvider(mzTolerance));
     }
 
     /**
-	 * <p>
-	 * Constructor for ChromatogramBuilderMethod.
-	 * </p>
-	 *
-	 * @param dataPointStore
-	 *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
-	 *            object.
-	 * @param inputFile
-	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
-	 * @param inputScans
-	 *            a {@link java.util.List} object.
-	 * @param minimumTimeSpan
-	 *            a {@link java.lang.Double} object.
-	 * @param minimumHeight
-	 *            a {@link java.lang.Double} object.
-	 * @param mzToleranceProvider
-	 *            an object that implements the
-	 *            {@link io.github.msdk.util.tolerances.MZToleranceProvider}
-	 *            interface.
-	 * @param noiseLevel
-	 *            a {@link java.lang.Float} object.
-	 */
-	public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
-			@Nonnull RawDataFile inputFile, @Nonnull List<MsScan> inputScans,
-			@Nonnull Double noiseLevel, @Nonnull Double minimumTimeSpan,
-			@Nonnull Double minimumHeight,
-			@Nonnull MzToleranceProvider mzToleranceProvider) {
-		this.dataPointStore = dataPointStore;
-		this.inputFile = inputFile;
-		this.inputScans = inputScans;
-		this.noiseLevel = noiseLevel;
-		this.minimumTimeSpan = minimumTimeSpan;
-		this.minimumHeight = minimumHeight;
-		this.mzToleranceProvider = mzToleranceProvider;
-	}
+     * <p>
+     * Constructor for ChromatogramBuilderMethod.
+     * </p>
+     *
+     * @param dataPointStore
+     *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
+     *            object.
+     * @param inputFile
+     *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+     * @param inputScans
+     *            a {@link java.util.List} object.
+     * @param minimumTimeSpan
+     *            a {@link java.lang.Double} object.
+     * @param minimumHeight
+     *            a {@link java.lang.Double} object.
+     * @param mzToleranceProvider
+     *            an object that implements the
+     *            {@link io.github.msdk.util.tolerances.MZToleranceProvider}
+     *            interface.
+     * @param noiseLevel
+     *            a {@link java.lang.Float} object.
+     */
+    public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
+            @Nonnull RawDataFile inputFile, @Nonnull List<MsScan> inputScans,
+            @Nonnull Double noiseLevel, @Nonnull Double minimumTimeSpan,
+            @Nonnull Double minimumHeight,
+            @Nonnull MzToleranceProvider mzToleranceProvider) {
+        this.dataPointStore = dataPointStore;
+        this.inputFile = inputFile;
+        this.inputScans = inputScans;
+        this.noiseLevel = noiseLevel;
+        this.minimumTimeSpan = minimumTimeSpan;
+        this.minimumHeight = minimumHeight;
+        this.mzToleranceProvider = mzToleranceProvider;
+    }
 
     /** {@inheritDoc} */
     @Override

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethod.java
@@ -31,6 +31,7 @@ import io.github.msdk.datamodel.rawdata.ChromatographyInfo;
 import io.github.msdk.datamodel.rawdata.MsScan;
 import io.github.msdk.datamodel.rawdata.RawDataFile;
 import io.github.msdk.util.tolerances.MzTolerance;
+import io.github.msdk.util.tolerances.MzToleranceProvider;
 
 /**
  * <p>
@@ -47,72 +48,77 @@ public class ChromatogramBuilderMethod
     private final @Nonnull List<MsScan> inputScans;
     private final @Nonnull Double noiseLevel;
     private final @Nonnull Double minimumTimeSpan, minimumHeight;
-    private final @Nonnull MzTolerance mzTolerance;
+    private final @Nonnull MzToleranceProvider mzToleranceProvider;
 
     private int processedScans = 0, totalScans = 0;
     private boolean canceled = false;
     private List<Chromatogram> result;
 
     /**
-     * <p>
-     * Constructor for ChromatogramBuilderMethod.
-     * </p>
-     *
-     * @param dataPointStore
-     *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
-     *            object.
-     * @param inputFile
-     *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
-     * @param minimumTimeSpan
-     *            a {@link java.lang.Double} object.
-     * @param minimumHeight
-     *            a {@link java.lang.Double} object.
-     * @param mzTolerance
-     *            an object that implements the {@link io.github.msdk.util.tolerances.MZTolerance} interface.
-     * @param noiseLevel
-     *            a {@link java.lang.Float} object.
-     */
+	 * <p>
+	 * Constructor for ChromatogramBuilderMethod.
+	 * </p>
+	 *
+	 * @param dataPointStore
+	 *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
+	 *            object.
+	 * @param inputFile
+	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+	 * @param minimumTimeSpan
+	 *            a {@link java.lang.Double} object.
+	 * @param minimumHeight
+	 *            a {@link java.lang.Double} object.
+	 * @param mzToleranceProvider
+	 *            an object that implements the
+	 *            {@link io.github.msdk.util.tolerances.MZToleranceProvider}
+	 *            interface.
+	 * @param noiseLevel
+	 *            a {@link java.lang.Float} object.
+	 */
     public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
             @Nonnull RawDataFile inputFile, @Nonnull Double noiseLevel,
             @Nonnull Double minimumTimeSpan, @Nonnull Double minimumHeight,
-            @Nonnull MzTolerance mzTolerance) {
+            @Nonnull MzToleranceProvider mzToleranceProvider) {
         this(dataPointStore, inputFile, inputFile.getScans(), noiseLevel,
-                minimumTimeSpan, minimumHeight, mzTolerance);
+                minimumTimeSpan, minimumHeight, mzToleranceProvider);
     }
 
     /**
-     * <p>
-     * Constructor for ChromatogramBuilderMethod.
-     * </p>
-     *
-     * @param dataPointStore
-     *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
-     *            object.
-     * @param inputFile
-     *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
-     * @param inputScans
-     *            a {@link java.util.List} object.
-     * @param minimumTimeSpan
-     *            a {@link java.lang.Double} object.
-     * @param minimumHeight
-     *            a {@link java.lang.Double} object.
-     * @param mzTolerance
-     *            an object that implements the {@link io.github.msdk.util.tolerances.MZTolerance} interface.
-     * @param noiseLevel
-     *            a {@link java.lang.Float} object.
-     */
-    public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
-            @Nonnull RawDataFile inputFile, @Nonnull List<MsScan> inputScans,
-            @Nonnull Double noiseLevel, @Nonnull Double minimumTimeSpan,
-            @Nonnull Double minimumHeight, @Nonnull MzTolerance mzTolerance) {
-        this.dataPointStore = dataPointStore;
-        this.inputFile = inputFile;
-        this.inputScans = inputScans;
-        this.noiseLevel = noiseLevel;
-        this.minimumTimeSpan = minimumTimeSpan;
-        this.minimumHeight = minimumHeight;
-        this.mzTolerance = mzTolerance;
-    }
+	 * <p>
+	 * Constructor for ChromatogramBuilderMethod.
+	 * </p>
+	 *
+	 * @param dataPointStore
+	 *            a {@link io.github.msdk.datamodel.datastore.DataPointStore}
+	 *            object.
+	 * @param inputFile
+	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+	 * @param inputScans
+	 *            a {@link java.util.List} object.
+	 * @param minimumTimeSpan
+	 *            a {@link java.lang.Double} object.
+	 * @param minimumHeight
+	 *            a {@link java.lang.Double} object.
+	 * @param mzToleranceProvider
+	 *            an object that implements the
+	 *            {@link io.github.msdk.util.tolerances.MZToleranceProvider}
+	 *            interface.
+	 * @param noiseLevel
+	 *            a {@link java.lang.Float} object.
+	 */
+	public ChromatogramBuilderMethod(@Nonnull DataPointStore dataPointStore,
+			@Nonnull RawDataFile inputFile, @Nonnull List<MsScan> inputScans,
+			@Nonnull Double noiseLevel, @Nonnull Double minimumTimeSpan,
+			@Nonnull Double minimumHeight,
+			@Nonnull MzToleranceProvider mzToleranceProvider) {
+		this.dataPointStore = dataPointStore;
+		this.inputFile = inputFile;
+		this.inputScans = inputScans;
+		this.noiseLevel = noiseLevel;
+		this.minimumTimeSpan = minimumTimeSpan;
+		this.minimumHeight = minimumHeight;
+		this.mzToleranceProvider = mzToleranceProvider;
+	}
 
     /** {@inheritDoc} */
     @Override
@@ -156,6 +162,7 @@ public class ChromatogramBuilderMethod
             if (canceled)
                 return null;
 
+            MzTolerance mzTolerance = mzToleranceProvider.getMzTolerance(scan);
             massConnector.addScan(inputFile, scan, mzTolerance);
             processedScans++;
         }

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/HighestDataPointConnector.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/HighestDataPointConnector.java
@@ -45,7 +45,6 @@ class HighestDataPointConnector {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final @Nonnull Double noiseLevel;
-    private final MzTolerance mzTolerance;
     private final double minimumTimeSpan, minimumHeight;
 
     private final Set<BuildingChromatogram> buildingChromatograms,
@@ -57,10 +56,9 @@ class HighestDataPointConnector {
     private float intensityBuffer[] = new float[10000];
 
     HighestDataPointConnector(@Nonnull Double noiseLevel, double minimumTimeSpan,
-            double minimumHeight, MzTolerance mzTolerance) {
+            double minimumHeight) {
 
         this.noiseLevel = noiseLevel;
-        this.mzTolerance = mzTolerance;
         this.minimumHeight = minimumHeight;
         this.minimumTimeSpan = minimumTimeSpan;
 
@@ -72,7 +70,7 @@ class HighestDataPointConnector {
 
     }
 
-    void addScan(RawDataFile dataFile, MsScan scan) {
+    void addScan(RawDataFile dataFile, MsScan scan, MzTolerance mzTolerance) {
 
         // Load data points
         mzBuffer = scan.getMzValues(mzBuffer);

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/HighestDataPointConnector.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/main/java/io/github/msdk/featdet/chromatogrambuilder/HighestDataPointConnector.java
@@ -55,7 +55,6 @@ class HighestDataPointConnector {
     private ChromatographyInfo rtBuffer[] = new ChromatographyInfo[10000];
     private double mzBuffer[] = new double[10000];
     private float intensityBuffer[] = new float[10000];
-    private int numOfDataPoints;
 
     HighestDataPointConnector(@Nonnull Double noiseLevel, double minimumTimeSpan,
             double minimumHeight, MzTolerance mzTolerance) {
@@ -78,7 +77,7 @@ class HighestDataPointConnector {
         // Load data points
         mzBuffer = scan.getMzValues(mzBuffer);
         intensityBuffer = scan.getIntensityValues(intensityBuffer);
-        numOfDataPoints = scan.getNumberOfDataPoints();
+        int numOfDataPoints = scan.getNumberOfDataPoints();
 
         // Sort m/z peaks by descending intensity
         DataPointSorter.sortDataPoints(mzBuffer, intensityBuffer,

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/test/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethodTest.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/test/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethodTest.java
@@ -29,7 +29,7 @@ import io.github.msdk.datamodel.rawdata.RawDataFile;
 import io.github.msdk.featdet.chromatogrambuilder.ChromatogramBuilderMethod;
 import io.github.msdk.io.mzml.MzMLFileImportMethod;
 import io.github.msdk.util.tolerances.ConstantPpmTolerance;
-import io.github.msdk.util.tolerances.MzToleranceProvider;
+import io.github.msdk.util.tolerances.MzTolerance;
 
 public class ChromatogramBuilderMethodTest {
 
@@ -61,10 +61,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0;
         double minimumTimeSpan = 6; // 6s
         double minimumHeight = 1E4;
-        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
+        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzToleranceProvider);
+                mzTolerance);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 
@@ -80,10 +80,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0;
         double minimumTimeSpan = 1000000;
         double minimumHeight = 1E4;
-        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
+        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzToleranceProvider);
+                mzTolerance);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 
@@ -100,10 +100,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0f;
         double minimumTimeSpan = 6; // 6s
         double minimumHeight = 10000000;
-        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
+        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzToleranceProvider);
+                mzTolerance);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 

--- a/msdk-featdet/msdk-featdet-chromatogrambuilder/src/test/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethodTest.java
+++ b/msdk-featdet/msdk-featdet-chromatogrambuilder/src/test/java/io/github/msdk/featdet/chromatogrambuilder/ChromatogramBuilderMethodTest.java
@@ -29,7 +29,7 @@ import io.github.msdk.datamodel.rawdata.RawDataFile;
 import io.github.msdk.featdet.chromatogrambuilder.ChromatogramBuilderMethod;
 import io.github.msdk.io.mzml.MzMLFileImportMethod;
 import io.github.msdk.util.tolerances.ConstantPpmTolerance;
-import io.github.msdk.util.tolerances.MzTolerance;
+import io.github.msdk.util.tolerances.MzToleranceProvider;
 
 public class ChromatogramBuilderMethodTest {
 
@@ -61,10 +61,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0;
         double minimumTimeSpan = 6; // 6s
         double minimumHeight = 1E4;
-        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
+        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzTolerance);
+                mzToleranceProvider);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 
@@ -80,10 +80,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0;
         double minimumTimeSpan = 1000000;
         double minimumHeight = 1E4;
-        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
+        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzTolerance);
+                mzToleranceProvider);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 
@@ -100,10 +100,10 @@ public class ChromatogramBuilderMethodTest {
         double noiseLevel = 0f;
         double minimumTimeSpan = 6; // 6s
         double minimumHeight = 10000000;
-        MzTolerance mzTolerance = new ConstantPpmTolerance(5.0);
+        MzToleranceProvider mzToleranceProvider = new ConstantPpmTolerance(5.0);
         ChromatogramBuilderMethod chromBuilder = new ChromatogramBuilderMethod(
                 dataStore, rawFile, noiseLevel, minimumTimeSpan, minimumHeight,
-                mzTolerance);
+                mzToleranceProvider);
         List<Chromatogram> detectedFeatures = chromBuilder.execute();
         Assert.assertEquals(1.0, chromBuilder.getFinishedPercentage(), 0.0001);
 


### PR DESCRIPTION
This is first step for having the chromatogram builder take advantage of the error bars provided by PeakInvestigator v1.4.

Second step will modifying ```ChromatogramBuilderMethod``` constructor to take a ```MzToleranceFactory``` interface instead of ```MzTolerance```. Proposed interface is:

```
interface MZToleranceFactory {
    MzTolerance getMzTolerance(MsScan scan);
}
```
