### PR TITLE
Fix some docstrings

### DIFF
--- a/msdk-datamodel/src/main/java/io/github/msdk/datamodel/rawdata/MsScan.java
+++ b/msdk-datamodel/src/main/java/io/github/msdk/datamodel/rawdata/MsScan.java
@@ -26,8 +26,8 @@ import io.github.msdk.datamodel.msspectra.MsSpectrum;
 
 /**
  * Represents a single MS scan in a raw data file. This interface extends
- * IMassSpectrum, therefore the actual data points can be accessed through the
- * inherited methods of IMassSpectrum.
+ * {@link io.github.msdk.datamodel.msspectra.MsSpectrum}, therefore the actual 
+ * data points can be accessed through the inherited methods of MsSpectrum.
  *
  * If the scan is not added to any file, its data points are stored in memory.
  * However, once the scan is added into a raw data file by calling


### PR DESCRIPTION
Came across a docstring that seemed outdated (i.e. references to ```IMassSpectrum```), which I've updated to ```MsSpectrum```.

The [docstring](https://github.com/msdk/msdk/blob/master/msdk-datamodel/src/main/java/io/github/msdk/datamodel/msspectra/MsSpectrum.java#L59) of ```MsSpectrum.getMzValues()``` also references ```DataPointList``` which seems outdated. I also see similar references in ```Chromatogram```, ```DataPointStore```, and ```MemoryDataPoint```.


