### PR TITLE
Improvements to the TxtExportAlgorithm

### DIFF
--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
@@ -37,11 +37,17 @@ import io.github.msdk.datamodel.msspectra.MsSpectrum;
 public class TxtExportAlgorithm {
 
     /**
-     * <p>Export a single spectrum to a file.</p>
+     * <p>
+     * Export a single spectrum to a file.
+     * </p>
      *
-     * @param exportFile a {@link java.io.File} object.
-     * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
-     * @throws java.io.IOException if any.
+     * @param exportFile
+     *            a {@link java.io.File} object.
+     * @param spectrum
+     *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
+     *            object.
+     * @throws java.io.IOException
+     *             if any.
      */
     @SuppressWarnings("null")
     public static void exportSpectrum(@Nonnull File exportFile,
@@ -72,13 +78,19 @@ public class TxtExportAlgorithm {
     }
 
     /**
-     * <p>Export one or more spectra to a file.</p>
+     * <p>
+     * Export one or more spectra to a file.
+     * </p>
      *
-     * @param exportFile a {@link java.io.File} object.
-     * @param spectra a {@link java.util.Collection} object.
-     * @param delimiter a {@link java.lang.String} object.
+     * @param exportFile
+     *            a {@link java.io.File} object.
+     * @param spectra
+     *            a {@link java.util.Collection} object.
+     * @param delimiter
+     *            a {@link java.lang.String} object.
      * 
-     * @throws java.io.IOException if any.
+     * @throws java.io.IOException
+     *             if any.
      * 
      * @see spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String
      *      delimiter)
@@ -113,15 +125,14 @@ public class TxtExportAlgorithm {
      * 
      * @throws java.io.IOException
      *             if any.
-     *             
-     * @see spectrumToString(MsSpectrum spectrum, String
-     *      delimiter)
+     * 
+     * @see spectrumToString(MsSpectrum spectrum, String delimiter)
      */
     public static void spectrumToWriter(@Nonnull MsSpectrum spectrum,
             @Nonnull Writer writer) throws IOException {
         spectrumToWriter(spectrum, writer, " ");
     }
- 
+
     /**
      * <p>
      * Export a spectrum to a writer.
@@ -156,7 +167,8 @@ public class TxtExportAlgorithm {
 
     /**
      * <p>
-     * Export a spectrum to a string. Uses a {@link java.io.StringWriter} object.
+     * Export a spectrum to a string. Uses a {@link java.io.StringWriter}
+     * object.
      * </p>
      * A single space is used as the delimiter.
      *
@@ -165,9 +177,9 @@ public class TxtExportAlgorithm {
      *            object.
      * @return a {@link java.lang.String} object.
      * 
-     * @see  spectrumToString(MsSpectrum spectrum, String
+     * @see spectrumToString(MsSpectrum spectrum, String delimiter)
+     * @see spectrumToWriter(MsSpectrum spectrum, Writer writer, String
      *      delimiter)
-     * @see spectrumToWriter(MsSpectrum spectrum, Writer writer, String delimiter)
      */
     public static @Nonnull String spectrumToString(
             @Nonnull MsSpectrum spectrum) {
@@ -175,17 +187,24 @@ public class TxtExportAlgorithm {
     }
 
     /**
-     * <p>Export a spectrum to a string. Uses a {@link java.io.StringWriter} object.</p>
+     * <p>
+     * Export a spectrum to a string. Uses a {@link java.io.StringWriter}
+     * object.
+     * </p>
      *
-     * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
-     * @param delimiter a {@link java.lang.String} object.
+     * @param spectrum
+     *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
+     *            object.
+     * @param delimiter
+     *            a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
      * 
-     * @see spectrumToWriter(MsSpectrum spectrum,
-            Writer writer, String delimiter)
+     * @see spectrumToWriter(MsSpectrum spectrum, Writer writer, String
+     *      delimiter)
      */
     @SuppressWarnings("null")
-	public static @Nonnull String spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String delimiter) {
+    public static @Nonnull String spectrumToString(@Nonnull MsSpectrum spectrum,
+            @Nonnull String delimiter) {
 
         StringWriter sw = new StringWriter();
         try {

--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
@@ -28,12 +28,16 @@ import javax.annotation.Nonnull;
 import io.github.msdk.datamodel.msspectra.MsSpectrum;
 
 /**
- * <p>TxtExportAlgorithm class.</p>
+ * <p>
+ * A class containing methods to export
+ * {@link io.github.msdk.datamodel.msspectra.MsSpectrum} objects to string
+ * representations or files.
+ * </p>
  */
 public class TxtExportAlgorithm {
 
     /**
-     * <p>exportSpectrum.</p>
+     * <p>Export a single spectrum to a file.</p>
      *
      * @param exportFile a {@link java.io.File} object.
      * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
@@ -47,9 +51,9 @@ public class TxtExportAlgorithm {
 
     /**
      * <p>
-     * exportSpectra.
+     * Export one or more spectra to a file. A single space is used as the
+     * delimiter.
      * </p>
-     * A single space is used as the delimiter.
      *
      * @param exportFile
      *            a {@link java.io.File} object.
@@ -57,6 +61,10 @@ public class TxtExportAlgorithm {
      *            a {@link java.util.Collection} object.
      * @throws java.io.IOException
      *             if any.
+     * @see exportSpectra(File exportFile, Collection<MsSpectrum> spectra,
+     *      String delimiter)
+     * @see spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String
+     *      delimiter)
      */
     public static void exportSpectra(@Nonnull File exportFile,
             @Nonnull Collection<MsSpectrum> spectra) throws IOException {
@@ -64,13 +72,16 @@ public class TxtExportAlgorithm {
     }
 
     /**
-     * <p>exportSpectra.</p>
+     * <p>Export one or more spectra to a file.</p>
      *
      * @param exportFile a {@link java.io.File} object.
      * @param spectra a {@link java.util.Collection} object.
      * @param delimiter a {@link java.lang.String} object.
      * 
      * @throws java.io.IOException if any.
+     * 
+     * @see spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String
+     *      delimiter)
      */
     public static void exportSpectra(@Nonnull File exportFile,
             @Nonnull Collection<MsSpectrum> spectra, @Nonnull String delimiter)
@@ -91,7 +102,7 @@ public class TxtExportAlgorithm {
 
     /**
      * <p>
-     * spectrumToWriter. A single space is used as the delimiter.
+     * Export a spectrum to a writer. A single space is used as the delimiter.
      * </p>
      *
      * @param spectrum
@@ -102,6 +113,9 @@ public class TxtExportAlgorithm {
      * 
      * @throws java.io.IOException
      *             if any.
+     *             
+     * @see spectrumToString(MsSpectrum spectrum, String
+     *      delimiter)
      */
     public static void spectrumToWriter(@Nonnull MsSpectrum spectrum,
             @Nonnull Writer writer) throws IOException {
@@ -110,7 +124,7 @@ public class TxtExportAlgorithm {
  
     /**
      * <p>
-     * spectrumToWriter.
+     * Export a spectrum to a writer.
      * </p>
      *
      * @param spectrum
@@ -142,7 +156,7 @@ public class TxtExportAlgorithm {
 
     /**
      * <p>
-     * spectrumToString.
+     * Export a spectrum to a string. Uses a {@link java.io.StringWriter} object.
      * </p>
      * A single space is used as the delimiter.
      *
@@ -150,6 +164,10 @@ public class TxtExportAlgorithm {
      *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
      *            object.
      * @return a {@link java.lang.String} object.
+     * 
+     * @see  spectrumToString(MsSpectrum spectrum, String
+     *      delimiter)
+     * @see spectrumToWriter(MsSpectrum spectrum, Writer writer, String delimiter)
      */
     public static @Nonnull String spectrumToString(
             @Nonnull MsSpectrum spectrum) {
@@ -157,11 +175,14 @@ public class TxtExportAlgorithm {
     }
 
     /**
-     * <p>spectrumToString.</p>
+     * <p>Export a spectrum to a string. Uses a {@link java.io.StringWriter} object.</p>
      *
      * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
      * @param delimiter a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
+     * 
+     * @see spectrumToWriter(MsSpectrum spectrum,
+            Writer writer, String delimiter)
      */
     @SuppressWarnings("null")
 	public static @Nonnull String spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String delimiter) {

--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
@@ -46,14 +46,35 @@ public class TxtExportAlgorithm {
     }
 
     /**
+     * <p>
+     * exportSpectra.
+     * </p>
+     * A single space is used as the delimiter.
+     *
+     * @param exportFile
+     *            a {@link java.io.File} object.
+     * @param spectra
+     *            a {@link java.util.Collection} object.
+     * @throws java.io.IOException
+     *             if any.
+     */
+    public static void exportSpectra(@Nonnull File exportFile,
+            @Nonnull Collection<MsSpectrum> spectra) throws IOException {
+        exportSpectra(exportFile, spectra, " ");
+    }
+
+    /**
      * <p>exportSpectra.</p>
      *
      * @param exportFile a {@link java.io.File} object.
      * @param spectra a {@link java.util.Collection} object.
+     * @param delimiter a {@link java.lang.String} object.
+     * 
      * @throws java.io.IOException if any.
      */
     public static void exportSpectra(@Nonnull File exportFile,
-            @Nonnull Collection<MsSpectrum> spectra) throws IOException {
+            @Nonnull Collection<MsSpectrum> spectra, @Nonnull String delimiter)
+            throws IOException {
 
         // Open the writer
         final BufferedWriter writer = new BufferedWriter(
@@ -61,7 +82,7 @@ public class TxtExportAlgorithm {
 
         // Write the data points
         for (MsSpectrum spectrum : spectra) {
-            spectrumToWriter(spectrum, writer);
+            spectrumToWriter(spectrum, writer, delimiter);
         }
 
         writer.close();
@@ -69,14 +90,43 @@ public class TxtExportAlgorithm {
     }
 
     /**
-     * <p>spectrumToWriter.</p>
+     * <p>
+     * spectrumToWriter. A single space is used as the delimiter.
+     * </p>
      *
-     * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
-     * @param writer a {@link java.io.Writer} object.
-     * @throws java.io.IOException if any.
+     * @param spectrum
+     *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
+     *            object.
+     * @param writer
+     *            a {@link java.io.Writer} object.
+     * 
+     * @throws java.io.IOException
+     *             if any.
      */
     public static void spectrumToWriter(@Nonnull MsSpectrum spectrum,
             @Nonnull Writer writer) throws IOException {
+        spectrumToWriter(spectrum, writer, " ");
+    }
+ 
+    /**
+     * <p>
+     * spectrumToWriter.
+     * </p>
+     *
+     * @param spectrum
+     *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
+     *            object.
+     * @param writer
+     *            a {@link java.io.Writer} object.
+     * @param delimiter
+     *            a {@link java.lang.String object}.
+     * 
+     * @throws java.io.IOException
+     *             if any.
+     */
+    public static void spectrumToWriter(@Nonnull MsSpectrum spectrum,
+            @Nonnull Writer writer, @Nonnull String delimiter)
+            throws IOException {
 
         double mzValues[] = spectrum.getMzValues();
         float intensityValues[] = spectrum.getIntensityValues();
@@ -84,25 +134,41 @@ public class TxtExportAlgorithm {
 
         for (int i = 0; i < numOfDataPoints; i++) {
             // Write data point row
-            writer.write(mzValues[i] + " " + intensityValues[i]);
+            writer.write(mzValues[i] + delimiter + intensityValues[i]);
             writer.write(System.lineSeparator());
         }
 
     }
 
     /**
+     * <p>
+     * spectrumToString.
+     * </p>
+     * A single space is used as the delimiter.
+     *
+     * @param spectrum
+     *            a {@link io.github.msdk.datamodel.msspectra.MsSpectrum}
+     *            object.
+     * @return a {@link java.lang.String} object.
+     */
+    public static @Nonnull String spectrumToString(
+            @Nonnull MsSpectrum spectrum) {
+        return spectrumToString(spectrum, " ");
+    }
+
+    /**
      * <p>spectrumToString.</p>
      *
      * @param spectrum a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
+     * @param delimiter a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
      */
     @SuppressWarnings("null")
-    public static @Nonnull String spectrumToString(
-            @Nonnull MsSpectrum spectrum) {
+	public static @Nonnull String spectrumToString(@Nonnull MsSpectrum spectrum, @Nonnull String delimiter) {
 
         StringWriter sw = new StringWriter();
         try {
-            spectrumToWriter(spectrum, sw);
+            spectrumToWriter(spectrum, sw, delimiter);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
@@ -1,0 +1,84 @@
+package io.github.msdk.io.txt;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.arrayContaining;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import io.github.msdk.datamodel.msspectra.MsSpectrum;
+
+public class TxtExportAlgorithmTest {
+
+	private static final double[] mzValues1 = { 100.0, 200.0 };
+	private static final float[] intensityValues1 = { 10.0f, 20.0f };
+
+	private static final double[] mzValues2 = { 300.0, 400.0 };
+	private static final float[] intensityValues2 = { 30.0f, 40.0f };
+
+	private static final String[] expectedSimple = { "100.0 10.0", "200.0 20.0" };
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Test
+	public void testExportSpectrum() throws IOException {
+		File file = folder.newFile();
+		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+
+		TxtExportAlgorithm.exportSpectrum(file, spectrum);
+
+		List<String> lines = Files.readAllLines(file.toPath(), Charset.defaultCharset());
+		assertThat(lines.toArray(new String[lines.size()]), arrayContaining(expectedSimple));
+	}
+
+	private static final String[] expectedTwoSpectra = { "100.0 10.0", "200.0 20.0", "300.0 30.0", "400.0 40.0" };
+
+	@Test
+	public void testExportSpectra() throws IOException {
+		File file = folder.newFile();
+		Collection<MsSpectrum> spectra = new ArrayList<>();
+
+		spectra.add(mockSpectrum(mzValues1, intensityValues1));
+		spectra.add(mockSpectrum(mzValues2, intensityValues2));
+
+		TxtExportAlgorithm.exportSpectra(file, spectra);
+
+		List<String> lines = Files.readAllLines(file.toPath(), Charset.defaultCharset());
+		assertThat(lines.toArray(new String[lines.size()]), arrayContaining(expectedTwoSpectra));
+	}
+
+	@Test
+	public void testSpectrumToString() {
+		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+
+		String result = TxtExportAlgorithm.spectrumToString(spectrum);
+		String lines[] = result.split("\\r?\\n");
+		assertThat(lines, arrayContaining(expectedSimple));
+	}
+
+	private MsSpectrum mockSpectrum(double[] mzValues, float[] intensityValues) {
+
+		if (mzValues.length != intensityValues.length) {
+			fail("Inconsistent sizes when mocking spectrum.");
+		}
+
+		MsSpectrum spectrum = mock(MsSpectrum.class);
+		when(spectrum.getMzValues()).thenReturn(mzValues);
+		when(spectrum.getIntensityValues()).thenReturn(intensityValues);
+		when(spectrum.getNumberOfDataPoints()).thenReturn(mzValues.length);
+
+		return spectrum;
+	}
+}

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
@@ -28,6 +28,7 @@ public class TxtExportAlgorithmTest {
 	private static final float[] intensityValues2 = { 30.0f, 40.0f };
 
 	private static final String[] expectedSimple = { "100.0 10.0", "200.0 20.0" };
+	private static final String[] expectedSimpleWithTabs = { "100.0\t10.0", "200.0\t20.0" };
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
@@ -66,6 +67,15 @@ public class TxtExportAlgorithmTest {
 		String result = TxtExportAlgorithm.spectrumToString(spectrum);
 		String lines[] = result.split("\\r?\\n");
 		assertThat(lines, arrayContaining(expectedSimple));
+	}
+
+	@Test
+	public void testSpectrumToStringWithTabs() {
+		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+
+		String result = TxtExportAlgorithm.spectrumToString(spectrum, "\t");
+		String lines[] = result.split("\\r?\\n");
+		assertThat(lines, arrayContaining(expectedSimpleWithTabs));
 	}
 
 	private MsSpectrum mockSpectrum(double[] mzValues, float[] intensityValues) {

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
@@ -21,74 +21,82 @@ import io.github.msdk.datamodel.msspectra.MsSpectrum;
 
 public class TxtExportAlgorithmTest {
 
-	private static final double[] mzValues1 = { 100.0, 200.0 };
-	private static final float[] intensityValues1 = { 10.0f, 20.0f };
+    private static final double[] mzValues1 = { 100.0, 200.0 };
+    private static final float[] intensityValues1 = { 10.0f, 20.0f };
 
-	private static final double[] mzValues2 = { 300.0, 400.0 };
-	private static final float[] intensityValues2 = { 30.0f, 40.0f };
+    private static final double[] mzValues2 = { 300.0, 400.0 };
+    private static final float[] intensityValues2 = { 30.0f, 40.0f };
 
-	private static final String[] expectedSimple = { "100.0 10.0", "200.0 20.0" };
-	private static final String[] expectedSimpleWithTabs = { "100.0\t10.0", "200.0\t20.0" };
+    private static final String[] expectedSimple = { "100.0 10.0",
+            "200.0 20.0" };
+    private static final String[] expectedSimpleWithTabs = { "100.0\t10.0",
+            "200.0\t20.0" };
 
-	@Rule
-	public TemporaryFolder folder = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
-	@Test
-	public void testExportSpectrum() throws IOException {
-		File file = folder.newFile();
-		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+    @Test
+    public void testExportSpectrum() throws IOException {
+        File file = folder.newFile();
+        MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
 
-		TxtExportAlgorithm.exportSpectrum(file, spectrum);
+        TxtExportAlgorithm.exportSpectrum(file, spectrum);
 
-		List<String> lines = Files.readAllLines(file.toPath(), Charset.defaultCharset());
-		assertThat(lines.toArray(new String[lines.size()]), arrayContaining(expectedSimple));
-	}
+        List<String> lines = Files.readAllLines(file.toPath(),
+                Charset.defaultCharset());
+        assertThat(lines.toArray(new String[lines.size()]),
+                arrayContaining(expectedSimple));
+    }
 
-	private static final String[] expectedTwoSpectra = { "100.0 10.0", "200.0 20.0", "300.0 30.0", "400.0 40.0" };
+    private static final String[] expectedTwoSpectra = { "100.0 10.0",
+            "200.0 20.0", "300.0 30.0", "400.0 40.0" };
 
-	@Test
-	public void testExportSpectra() throws IOException {
-		File file = folder.newFile();
-		Collection<MsSpectrum> spectra = new ArrayList<>();
+    @Test
+    public void testExportSpectra() throws IOException {
+        File file = folder.newFile();
+        Collection<MsSpectrum> spectra = new ArrayList<>();
 
-		spectra.add(mockSpectrum(mzValues1, intensityValues1));
-		spectra.add(mockSpectrum(mzValues2, intensityValues2));
+        spectra.add(mockSpectrum(mzValues1, intensityValues1));
+        spectra.add(mockSpectrum(mzValues2, intensityValues2));
 
-		TxtExportAlgorithm.exportSpectra(file, spectra);
+        TxtExportAlgorithm.exportSpectra(file, spectra);
 
-		List<String> lines = Files.readAllLines(file.toPath(), Charset.defaultCharset());
-		assertThat(lines.toArray(new String[lines.size()]), arrayContaining(expectedTwoSpectra));
-	}
+        List<String> lines = Files.readAllLines(file.toPath(),
+                Charset.defaultCharset());
+        assertThat(lines.toArray(new String[lines.size()]),
+                arrayContaining(expectedTwoSpectra));
+    }
 
-	@Test
-	public void testSpectrumToString() {
-		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+    @Test
+    public void testSpectrumToString() {
+        MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
 
-		String result = TxtExportAlgorithm.spectrumToString(spectrum);
-		String lines[] = result.split("\\r?\\n");
-		assertThat(lines, arrayContaining(expectedSimple));
-	}
+        String result = TxtExportAlgorithm.spectrumToString(spectrum);
+        String lines[] = result.split("\\r?\\n");
+        assertThat(lines, arrayContaining(expectedSimple));
+    }
 
-	@Test
-	public void testSpectrumToStringWithTabs() {
-		MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
+    @Test
+    public void testSpectrumToStringWithTabs() {
+        MsSpectrum spectrum = mockSpectrum(mzValues1, intensityValues1);
 
-		String result = TxtExportAlgorithm.spectrumToString(spectrum, "\t");
-		String lines[] = result.split("\\r?\\n");
-		assertThat(lines, arrayContaining(expectedSimpleWithTabs));
-	}
+        String result = TxtExportAlgorithm.spectrumToString(spectrum, "\t");
+        String lines[] = result.split("\\r?\\n");
+        assertThat(lines, arrayContaining(expectedSimpleWithTabs));
+    }
 
-	private MsSpectrum mockSpectrum(double[] mzValues, float[] intensityValues) {
+    private MsSpectrum mockSpectrum(double[] mzValues,
+            float[] intensityValues) {
 
-		if (mzValues.length != intensityValues.length) {
-			fail("Inconsistent sizes when mocking spectrum.");
-		}
+        if (mzValues.length != intensityValues.length) {
+            fail("Inconsistent sizes when mocking spectrum.");
+        }
 
-		MsSpectrum spectrum = mock(MsSpectrum.class);
-		when(spectrum.getMzValues()).thenReturn(mzValues);
-		when(spectrum.getIntensityValues()).thenReturn(intensityValues);
-		when(spectrum.getNumberOfDataPoints()).thenReturn(mzValues.length);
+        MsSpectrum spectrum = mock(MsSpectrum.class);
+        when(spectrum.getMzValues()).thenReturn(mzValues);
+        when(spectrum.getIntensityValues()).thenReturn(intensityValues);
+        when(spectrum.getNumberOfDataPoints()).thenReturn(mzValues.length);
 
-		return spectrum;
-	}
+        return spectrum;
+    }
 }


### PR DESCRIPTION
Add methods that take optional ```String``` delimiter, and make original method signatures delegate to these new methods. ```String``` was chosen over ```char``` because delimiters such as ```, ``` (comma-space) may be desired.

Also implemented tests and improved documentation.
