### PR TITLE
Print new line between spectra during text export

### DIFF
--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtExportAlgorithm.java
@@ -106,6 +106,7 @@ public class TxtExportAlgorithm {
         // Write the data points
         for (MsSpectrum spectrum : spectra) {
             spectrumToWriter(spectrum, writer, delimiter);
+            writer.newLine();
         }
 
         writer.close();

--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
@@ -14,6 +14,8 @@
 
 package io.github.msdk.io.txt;
 
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Scanner;
 import java.util.regex.Matcher;
@@ -39,16 +41,13 @@ public class TxtImportAlgorithm {
             .compile("(\\d+(\\.\\d+)?)[^\\d]+(\\d+(\\.\\d+)?)");
 
     /**
-     * Parse a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object from
-     * two-column text data.
-     * 
-     * <p>
-     * This version returns a SimpleMsSpectrum instance.
-     * </p>
+     * Parse a {@link io.github.msdk.datamodel.impl.SimpleMsSpectrum} object
+     * from the given string that has input data in two columns.
      * 
      * @param scanner
-     *            An open scanner object
-     * @return A MsSpectrum object containing the parsed data.
+     *            An open {@link java.util.Scanner} object.
+     * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
+     *         containing the parsed data.
      */
     private static @Nonnull MsSpectrum parseMsSpectrum(
             @Nonnull Scanner scanner) {
@@ -88,15 +87,33 @@ public class TxtImportAlgorithm {
     }
 
     /**
-     * <p>parseMsSpectrum.</p>
-     *
-     * @param spectrumText a {@link java.lang.String} object.
-     * @return a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
+     * Parse a {@link io.github.msdk.datamodel.impl.SimpleMsSpectrum} object
+     * from the given string that has input data in two columns.
+     * 
+     * @param spectrumText
+     *            A {@link java.lang.String} containing the input text.
+     * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
+     *         containing the parsed data.
      */
     public static @Nonnull MsSpectrum parseMsSpectrum(
             @Nonnull String spectrumText) {
 
-        Scanner scanner = new Scanner(spectrumText);
+        return parseMsSpectrum(new StringReader(spectrumText));
+    }
+
+    /**
+     * Parse a {@link io.github.msdk.datamodel.impl.SimpleMsSpectrum} object
+     * from the given readers. The reader is closed when this method returns.
+     * 
+     * @param reader
+     *            An open @{java.io.Reader} object that provides the data in two
+     *            columns.
+     * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
+     *         containing the parsed data.
+     */
+    public static @Nonnull MsSpectrum parseMsSpectrum(@Nonnull Reader reader) {
+
+        Scanner scanner = new Scanner(reader);
         MsSpectrum result = parseMsSpectrum(scanner);
         scanner.close();
 

--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
@@ -16,7 +16,9 @@ package io.github.msdk.io.txt;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -60,7 +62,7 @@ public class TxtImportAlgorithm {
             String line = scanner.nextLine();
             Matcher m = linePattern.matcher(line);
             if (!m.find())
-                continue;
+                break;
 
             String mzString = m.group(1);
             String intensityString = m.group(3);
@@ -72,6 +74,10 @@ public class TxtImportAlgorithm {
                     size);
             size++;
 
+        }
+
+        if (size == 0) {
+            return null;
         }
 
         // Sort the data points, in case they were not ordered
@@ -95,10 +101,16 @@ public class TxtImportAlgorithm {
      * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
      *         containing the parsed data.
      */
-    public static @Nonnull MsSpectrum parseMsSpectrum(
-            @Nonnull String spectrumText) {
+    public static MsSpectrum parseMsSpectrum(@Nonnull String spectrumText) {
 
-        return parseMsSpectrum(new StringReader(spectrumText));
+        Collection<MsSpectrum> result = parseMsSpectra(
+                new StringReader(spectrumText));
+        if (result.size() == 0) {
+            return null;
+        }
+
+        Iterator<MsSpectrum> iterator = result.iterator();
+        return iterator.next();
     }
 
     /**
@@ -108,15 +120,45 @@ public class TxtImportAlgorithm {
      * @param reader
      *            An open @{java.io.Reader} object that provides the data in two
      *            columns.
-     * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
+     * @return A {@link java.util.Collection} of
+     *         {@link io.github.msdk.datamodel.msspectra.MsSpectrum} objects
      *         containing the parsed data.
      */
-    public static @Nonnull MsSpectrum parseMsSpectrum(@Nonnull Reader reader) {
+    public static @Nonnull Collection<MsSpectrum> parseMsSpectra(@Nonnull Reader reader) {
 
+        Collection<MsSpectrum> result = new ArrayList<>();
         Scanner scanner = new Scanner(reader);
-        MsSpectrum result = parseMsSpectrum(scanner);
+
+        while(scanner.hasNextLine()) {
+            MsSpectrum spectrum = parseMsSpectrum(scanner);
+            if (spectrum != null) {
+                result.add(spectrum);
+            }
+        }
         scanner.close();
 
         return result;
+    }
+ 
+    /**
+     * Parse a collection (i.e. ArrayList) of
+     * {@link io.github.msdk.datamodel.impl.SimpleMsSpectrum} objects from the
+     * given readers. The reader is closed when this method returns.
+     * 
+     * @param reader
+     *            An open @{java.io.Reader} object that provides the data in two
+     *            columns.
+     * @return A {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object
+     *         containing the parsed data, or null if the data could not be parsed.
+     */
+    public static MsSpectrum parseMsSpectrum(@Nonnull Reader reader) {
+
+        Collection<MsSpectrum> result = parseMsSpectra(reader);
+        if (result.size() == 0) {
+            return null;
+        }
+
+        Iterator<MsSpectrum> iterator = result.iterator();
+        return iterator.next();
     }
 }

--- a/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
+++ b/msdk-io/msdk-io-txt/src/main/java/io/github/msdk/io/txt/TxtImportAlgorithm.java
@@ -39,19 +39,24 @@ public class TxtImportAlgorithm {
             .compile("(\\d+(\\.\\d+)?)[^\\d]+(\\d+(\\.\\d+)?)");
 
     /**
-     * <p>parseMsSpectrum.</p>
-     *
-     * @param spectrumText a {@link java.lang.String} object.
-     * @return a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
+     * Parse a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object from
+     * two-column text data.
+     * 
+     * <p>
+     * This version returns a SimpleMsSpectrum instance.
+     * </p>
+     * 
+     * @param scanner
+     *            An open scanner object
+     * @return A MsSpectrum object containing the parsed data.
      */
-    public static @Nonnull MsSpectrum parseMsSpectrum(
-            @Nonnull String spectrumText) {
+    private static @Nonnull MsSpectrum parseMsSpectrum(
+            @Nonnull Scanner scanner) {
 
         double mzValues[] = new double[16];
         float intensityValues[] = new float[16];
         int size = 0;
 
-        Scanner scanner = new Scanner(spectrumText);
         while (scanner.hasNextLine()) {
             String line = scanner.nextLine();
             Matcher m = linePattern.matcher(line);
@@ -67,8 +72,8 @@ public class TxtImportAlgorithm {
             intensityValues = ArrayUtil.addToArray(intensityValues, intensity,
                     size);
             size++;
+
         }
-        scanner.close();
 
         // Sort the data points, in case they were not ordered
         DataPointSorter.sortDataPoints(mzValues, intensityValues, size,
@@ -80,6 +85,21 @@ public class TxtImportAlgorithm {
                 intensityValues, size, specType);
 
         return result;
+    }
 
+    /**
+     * <p>parseMsSpectrum.</p>
+     *
+     * @param spectrumText a {@link java.lang.String} object.
+     * @return a {@link io.github.msdk.datamodel.msspectra.MsSpectrum} object.
+     */
+    public static @Nonnull MsSpectrum parseMsSpectrum(
+            @Nonnull String spectrumText) {
+
+        Scanner scanner = new Scanner(spectrumText);
+        MsSpectrum result = parseMsSpectrum(scanner);
+        scanner.close();
+
+        return result;
     }
 }

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtExportAlgorithmTest.java
@@ -4,14 +4,18 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyString;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,12 +48,15 @@ public class TxtExportAlgorithmTest {
 
         List<String> lines = Files.readAllLines(file.toPath(),
                 Charset.defaultCharset());
+        String empty = lines.remove(lines.size() - 1); // hack to remove empty
+                                                       // last line
+        assertThat(empty, isEmptyString());
         assertThat(lines.toArray(new String[lines.size()]),
                 arrayContaining(expectedSimple));
     }
 
     private static final String[] expectedTwoSpectra = { "100.0 10.0",
-            "200.0 20.0", "300.0 30.0", "400.0 40.0" };
+            "200.0 20.0", "", "300.0 30.0", "400.0 40.0", "" };
 
     @Test
     public void testExportSpectra() throws IOException {
@@ -65,6 +72,28 @@ public class TxtExportAlgorithmTest {
                 Charset.defaultCharset());
         assertThat(lines.toArray(new String[lines.size()]),
                 arrayContaining(expectedTwoSpectra));
+
+        Collection<MsSpectrum> importedSpectra = TxtImportAlgorithm
+                .parseMsSpectra(new FileReader(file));
+        assertThat(importedSpectra.size(), equalTo(2));
+
+        Iterator<MsSpectrum> iterator = importedSpectra.iterator();
+
+        MsSpectrum spectrum = iterator.next();
+        assertThat(spectrum.getMzValues()[0], equalTo(mzValues1[0]));
+        assertThat(spectrum.getMzValues()[1], equalTo(mzValues1[1]));
+        assertThat(spectrum.getIntensityValues()[0],
+                equalTo(intensityValues1[0]));
+        assertThat(spectrum.getIntensityValues()[1],
+                equalTo(intensityValues1[1]));
+
+        spectrum = iterator.next();
+        assertThat(spectrum.getMzValues()[0], equalTo(mzValues2[0]));
+        assertThat(spectrum.getMzValues()[1], equalTo(mzValues2[1]));
+        assertThat(spectrum.getIntensityValues()[0],
+                equalTo(intensityValues2[0]));
+        assertThat(spectrum.getIntensityValues()[1],
+                equalTo(intensityValues2[1]));
     }
 
     @Test

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
@@ -22,7 +22,6 @@ import java.io.StringReader;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,12 +47,12 @@ public class TxtImportAlgorithmTest {
         MsSpectrum spectrum = TxtImportAlgorithm
                 .parseMsSpectrum(spectrumText);
 
-        Assert.assertEquals(new Integer(4), spectrum.getNumberOfDataPoints());
+        assertThat(spectrum.getNumberOfDataPoints(), equalTo(4));
 
-        Assert.assertEquals(10.0, spectrum.getMzValues()[0], 0.0000001);
-        Assert.assertEquals(40.0, spectrum.getMzValues()[3], 0.0000001);
-        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[0], 0.0001);
-        Assert.assertEquals(300.0f, spectrum.getIntensityValues()[2], 0.00001);
+        assertThat(spectrum.getMzValues()[0], equalTo(10.0));
+        assertThat(spectrum.getMzValues()[3], equalTo(40.0));
+        assertThat(spectrum.getIntensityValues()[0], equalTo(100.0f));
+        assertThat(spectrum.getIntensityValues()[2], equalTo(300.0f));
 
     }
 
@@ -67,12 +66,12 @@ public class TxtImportAlgorithmTest {
         MsSpectrum spectrum = TxtImportAlgorithm
                 .parseMsSpectrum(new FileReader(file));
 
-        Assert.assertEquals(new Integer(4), spectrum.getNumberOfDataPoints());
+        assertThat(spectrum.getNumberOfDataPoints(), equalTo(4));
 
-        Assert.assertEquals(10.0, spectrum.getMzValues()[0], 0.0000001);
-        Assert.assertEquals(40.0, spectrum.getMzValues()[3], 0.0000001);
-        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[0], 0.0001);
-        Assert.assertEquals(300.0f, spectrum.getIntensityValues()[2], 0.00001);
+        assertThat(spectrum.getMzValues()[0], equalTo(10.0));
+        assertThat(spectrum.getMzValues()[3], equalTo(40.0));
+        assertThat(spectrum.getIntensityValues()[0], equalTo(100.0f));
+        assertThat(spectrum.getIntensityValues()[2], equalTo(300.0f));
     }
 
     @Test

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
@@ -32,7 +32,7 @@ public class TxtImportAlgorithmTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    private static String spectrumText = "10.0 20.0\n20.0 20.0\n30.0 100.0\n40.0 50.0";
+    private static String spectrumText = "10.0 100.0\n20.0 200.0\n30.0 300.0\n40.0 400.0";
 
     @Test
     public void test4Peaks() throws MSDKException {
@@ -44,8 +44,8 @@ public class TxtImportAlgorithmTest {
 
         Assert.assertEquals(10.0, spectrum.getMzValues()[0], 0.0000001);
         Assert.assertEquals(40.0, spectrum.getMzValues()[3], 0.0000001);
-        Assert.assertEquals(20.0f, spectrum.getIntensityValues()[0], 0.0001);
-        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[2], 0.00001);
+        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[0], 0.0001);
+        Assert.assertEquals(300.0f, spectrum.getIntensityValues()[2], 0.00001);
 
     }
 
@@ -63,8 +63,8 @@ public class TxtImportAlgorithmTest {
 
         Assert.assertEquals(10.0, spectrum.getMzValues()[0], 0.0000001);
         Assert.assertEquals(40.0, spectrum.getMzValues()[3], 0.0000001);
-        Assert.assertEquals(20.0f, spectrum.getIntensityValues()[0], 0.0001);
-        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[2], 0.00001);
+        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[0], 0.0001);
+        Assert.assertEquals(300.0f, spectrum.getIntensityValues()[2], 0.00001);
     }
 
 }

--- a/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
+++ b/msdk-io/msdk-io-txt/src/test/java/io/github/msdk/io/txt/TxtImportAlgorithmTest.java
@@ -14,18 +14,28 @@
 
 package io.github.msdk.io.txt;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import io.github.msdk.MSDKException;
 import io.github.msdk.datamodel.msspectra.MsSpectrum;
 
 public class TxtImportAlgorithmTest {
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static String spectrumText = "10.0 20.0\n20.0 20.0\n30.0 100.0\n40.0 50.0";
+
     @Test
     public void test4Peaks() throws MSDKException {
-
-        String spectrumText = "10.0 20.0\n20.0 20.0\n30.0 100.0\n40.0 50.0";
 
         MsSpectrum spectrum = TxtImportAlgorithm
                 .parseMsSpectrum(spectrumText);
@@ -37,6 +47,24 @@ public class TxtImportAlgorithmTest {
         Assert.assertEquals(20.0f, spectrum.getIntensityValues()[0], 0.0001);
         Assert.assertEquals(100.0f, spectrum.getIntensityValues()[2], 0.00001);
 
+    }
+
+    @Test
+    public void test4PeaksFromFile() throws IOException {
+        File file = folder.newFile();
+        FileWriter writer = new FileWriter(file);
+        writer.write(spectrumText);
+        writer.close();
+
+        MsSpectrum spectrum = TxtImportAlgorithm
+                .parseMsSpectrum(new FileReader(file));
+
+        Assert.assertEquals(new Integer(4), spectrum.getNumberOfDataPoints());
+
+        Assert.assertEquals(10.0, spectrum.getMzValues()[0], 0.0000001);
+        Assert.assertEquals(40.0, spectrum.getMzValues()[3], 0.0000001);
+        Assert.assertEquals(20.0f, spectrum.getIntensityValues()[0], 0.0001);
+        Assert.assertEquals(100.0f, spectrum.getIntensityValues()[2], 0.00001);
     }
 
 }


### PR DESCRIPTION
Modified both ```TxtExportAlgorithm``` and ```TxtImportAlgorithm``` to handle exporting multiple spectra in a single file to address #153. Blank lines are placed between each spectrum, and import now has function to return a collection (if expected) or just the first encountered spectrum.

Also some documentation fixes and test clean-up.
