### PR TITLE
Add module for centroiding data with PeakInvestigator

### DIFF
--- a/msdk-all/pom.xml
+++ b/msdk-all/pom.xml
@@ -126,6 +126,12 @@
 
 		<dependency>
 			<groupId>io.github.msdk</groupId>
+			<artifactId>msdk-rawdata-peakinvestigator</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.msdk</groupId>
 			<artifactId>msdk-rawdata-xic</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/msdk-rawdata/msdk-rawdata-peakinvestigator/pom.xml
+++ b/msdk-rawdata/msdk-rawdata-peakinvestigator/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.msdk</groupId>
+        <artifactId>msdk-rawdata</artifactId>
+        <version>0.0.7-SNAPSHOT</version>
+    </parent>
+    <artifactId>msdk-rawdata-peakinvestigator</artifactId>
+    <description>Package for PeakInvestigator centroiding algorithm</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.github.msdk</groupId>
+            <artifactId>msdk-datamodel</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.msdk</groupId>
+            <artifactId>msdk-io-txt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+        	<groupId>commons-io</groupId>
+        	<artifactId>commons-io</artifactId>
+        	<version>2.5</version>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.commons</groupId>
+        	<artifactId>commons-compress</artifactId>
+        	<version>1.12</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/msdk-rawdata/msdk-rawdata-peakinvestigator/src/main/java/io/github/msdk/rawdata/peakinvestigator/PeakInvestigatorScanBundlingMethod.java
+++ b/msdk-rawdata/msdk-rawdata-peakinvestigator/src/main/java/io/github/msdk/rawdata/peakinvestigator/PeakInvestigatorScanBundlingMethod.java
@@ -1,0 +1,174 @@
+/* 
+ * (C) Copyright 2015-2016 by MSDK Development Team
+ *
+ * This software is dual-licensed under either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+
+package io.github.msdk.rawdata.peakinvestigator;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.msdk.MSDKException;
+import io.github.msdk.MSDKMethod;
+
+import io.github.msdk.datamodel.rawdata.MsScan;
+import io.github.msdk.datamodel.rawdata.RawDataFile;
+
+import io.github.msdk.io.txt.TxtExportAlgorithm;
+
+/**
+ * <p>
+ * This class represents a method for bundling scans for upload to
+ * PeakInvestigator software services.
+ * </p>
+ */
+public class PeakInvestigatorScanBundlingMethod implements MSDKMethod<File> {
+
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private final @Nonnull File file;
+
+	private int processedScans = 0, totalScans = 0;
+	private RawDataFile rawDataFile;
+	private boolean canceled = false;
+
+	/**
+	 * <p>
+	 * Constructor for PeakInvestigatorScanBundlingMethod. A temporary file is
+	 * created, which will be deleted on JVM exit.
+	 * </p>
+	 *
+	 * @param rawDataFile
+	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+	 * @throws IOException
+	 */
+	public PeakInvestigatorScanBundlingMethod(@Nonnull RawDataFile rawDataFile) throws IOException {
+		this.rawDataFile = rawDataFile;
+		this.file = File.createTempFile("PI-", ".tar");
+		this.file.deleteOnExit();
+	}
+
+	/**
+	 * <p>
+	 * Constructor for PeakInvestigatorScanBundlingMethod.
+	 * </p>
+	 *
+	 * @param rawDataFile
+	 *            a {@link io.github.msdk.datamodel.rawdata.RawDataFile} object.
+	 * @param file
+	 *            a {@link java.io.File} object.
+	 */
+	public PeakInvestigatorScanBundlingMethod(@Nonnull RawDataFile rawDataFile, @Nonnull File file) {
+		this.rawDataFile = rawDataFile;
+		this.file = file;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public Float getFinishedPercentage() {
+		if (totalScans == 0) {
+			return null;
+		} else {
+			return (float) processedScans / totalScans;
+		}
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public File execute() throws MSDKException {
+
+		logger.info("Started bundling scans from file " + rawDataFile.getName());
+
+		List<MsScan> scans = rawDataFile.getScans();
+		totalScans = scans.size();
+
+		try (TarArchiveOutputStream tar = new TarArchiveOutputStream(
+				new GzipCompressorOutputStream(new FileOutputStream(file)))) {
+
+			for (MsScan scan : scans) {
+
+				if (canceled)
+					return null;
+
+				byte[] bytes = scanToBytes(scan);
+
+				TarArchiveEntry entry = new TarArchiveEntry(String.format("scan%05d.txt", scan.getScanNumber()));
+				entry.setSize(bytes.length);
+				entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+				entry.setModTime(new Date());
+				tar.putArchiveEntry(entry);
+
+				ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+				IOUtils.copy(inputStream, tar);
+				// Add the new scan to the created raw data file
+
+				tar.closeArchiveEntry();
+				processedScans++;
+			}
+
+		} catch (FileNotFoundException e) {
+			throw new MSDKException(e);
+		} catch (IOException e) {
+			throw new MSDKException(e);
+		}
+
+		logger.info("Finished bundling scans from file " + rawDataFile.getName());
+		return file;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public File getResult() {
+		return file;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void cancel() {
+		this.canceled = true;
+	}
+
+	/**
+	 * Helper method to convert a scan to a sequence of bytes.
+	 * 
+	 * @param scan
+	 *            An object that implements the {@link MsScan} interface.
+	 * @return A byte array containing the scan formatted as tab-delimited text.
+	 * @throws IOException
+	 * 
+	 * @see TxtExportAlgoirthm.spectrumToWriter()
+	 */
+	private byte[] scanToBytes(MsScan scan) throws IOException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(4 * scan.getNumberOfDataPoints());
+		OutputStreamWriter writer = new OutputStreamWriter(outputStream);
+		TxtExportAlgorithm.spectrumToWriter(scan, writer, "\t");
+		writer.close();
+		outputStream.close();
+		return outputStream.toByteArray();
+	}
+}

--- a/msdk-rawdata/msdk-rawdata-peakinvestigator/src/test/java/io/github/msdk/rawdata/peakinvestigator/PeakInvestigatorScanBundlingMethodTest.java
+++ b/msdk-rawdata/msdk-rawdata-peakinvestigator/src/test/java/io/github/msdk/rawdata/peakinvestigator/PeakInvestigatorScanBundlingMethodTest.java
@@ -1,0 +1,133 @@
+package io.github.msdk.rawdata.peakinvestigator;
+
+import static org.junit.Assert.*;
+
+import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import io.github.msdk.MSDKException;
+import io.github.msdk.datamodel.rawdata.MsScan;
+import io.github.msdk.datamodel.rawdata.RawDataFile;
+
+public class PeakInvestigatorScanBundlingMethodTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	private static int HEADER_SIZE = 512;
+
+	private final static double[] mzValues1 = { 1.0, 2.0 };
+	private final static float[] intensityValues1 = { 10.0f, 20.0f };
+
+	private final static double[] mzValues2 = { 3.0, 4.0 };
+	private final static float[] intensityValues2 = { 30.0f, 40.0f };
+
+	@Test
+	public void testExecuteOneScan() throws IOException, MSDKException {
+		List<MsScan> scans = new LinkedList<>();
+		scans.add(mockScan(0, mzValues1, intensityValues1));
+
+		RawDataFile rawDataFile = mockRawDataFile("SingleScan.raw", scans);
+
+		PeakInvestigatorScanBundlingMethod method = new PeakInvestigatorScanBundlingMethod(rawDataFile,
+				folder.newFile());
+		File file = method.execute();
+
+		assertThat(method.getFinishedPercentage(), equalTo(1.0f));
+
+		try (GzipCompressorInputStream stream = new GzipCompressorInputStream(new FileInputStream(file))) {
+			TarArchiveEntry entry = getEntryFromStream(stream);
+			assertThat(entry.getName(), equalTo("scan00000.txt"));
+
+			int size = (int) entry.getSize();
+			byte[] bytes = new byte[size];
+			assertThat(stream.read(bytes), equalTo(size));
+
+			BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
+			assertThat(reader.readLine(), equalTo("1.0\t10.0"));
+			assertThat(reader.readLine(), equalTo("2.0\t20.0"));
+		}
+	}
+
+	@Test
+	public void testExecuteTwoScans() throws IOException, MSDKException {
+		List<MsScan> scans = new LinkedList<>();
+		scans.add(mockScan(0, mzValues1, intensityValues1));
+		scans.add(mockScan(12, mzValues2, intensityValues2));
+
+		RawDataFile rawDataFile = mockRawDataFile("TwoScans.raw", scans);
+
+		PeakInvestigatorScanBundlingMethod method = new PeakInvestigatorScanBundlingMethod(rawDataFile,
+				folder.newFile());
+		File file = method.execute();
+
+		assertThat(method.getFinishedPercentage(), equalTo(1.0f));
+
+		try (GzipCompressorInputStream stream = new GzipCompressorInputStream(new FileInputStream(file))) {
+			TarArchiveEntry entry = getEntryFromStream(stream);
+			assertThat(entry.getName(), equalTo("scan00000.txt"));
+
+			int size = (int) entry.getSize();
+			byte[] bytes = new byte[size];
+			assertThat(stream.read(bytes), equalTo(size));
+
+			BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
+			assertThat(reader.readLine(), equalTo("1.0\t10.0"));
+			assertThat(reader.readLine(), equalTo("2.0\t20.0"));
+
+			stream.skip(HEADER_SIZE - size % HEADER_SIZE);
+			entry = getEntryFromStream(stream);
+			assertThat(entry.getName(), equalTo("scan00012.txt"));
+
+			size = (int) entry.getSize();
+			bytes = new byte[size];
+			assertThat(stream.read(bytes), equalTo(size));
+
+			reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
+			assertThat(reader.readLine(), equalTo("3.0\t30.0"));
+			assertThat(reader.readLine(), equalTo("4.0\t40.0"));
+		}
+
+	}
+
+	private MsScan mockScan(int scanNumber, double[] mzValues, float[] intensityValues) {
+		MsScan scan = mock(MsScan.class);
+		when(scan.getNumberOfDataPoints()).thenReturn(mzValues.length);
+		when(scan.getMzValues()).thenReturn(mzValues);
+		when(scan.getIntensityValues()).thenReturn(intensityValues);
+		when(scan.getScanNumber()).thenReturn(scanNumber);
+
+		return scan;
+	}
+
+	private RawDataFile mockRawDataFile(String name, List<MsScan> scans) {
+		RawDataFile rawDataFile = mock(RawDataFile.class);
+		when(rawDataFile.getName()).thenReturn(name);
+		when(rawDataFile.getScans()).thenReturn(scans);
+
+		return rawDataFile;
+	}
+
+	private TarArchiveEntry getEntryFromStream(InputStream stream) throws IOException {
+		byte[] header = new byte[HEADER_SIZE];
+		stream.read(header);
+		return new TarArchiveEntry(header);
+	}
+}

--- a/msdk-rawdata/pom.xml
+++ b/msdk-rawdata/pom.xml
@@ -14,6 +14,7 @@
 		<module>msdk-rawdata-filters</module>
 		<module>msdk-rawdata-centroiding</module>
 		<module>msdk-rawdata-baselinecorrection</module>
+		<module>msdk-rawdata-peakinvestigator</module>
 		<module>msdk-rawdata-xic</module>
 	</modules>
 


### PR DESCRIPTION
This pull request will add a module (```msdk-rawdata-peakinvestigator```) for centroiding data using PeakInvestigator. There's still a lot to do before it can be merged, but I wanted feedback before continuing.

- [x] Method to bundle scans into a tarball (```PeakInvestigatorScanBundlingMethod```)
- [ ] Method to extract mass lists from tarball (```PeakInvestigatorScanExtractingMethod``` ?)
- [ ] Method to transfer files to/from SFTP server (```PeakInvestigatorFileTransferMethod``` ?)
- [ ] Method(s) to interact with the PeakInvestigator API

If any of those methods would be of general use (e.g. ```TarExportMethod```), let me know and I'll move them to other modules.
