### PR TITLE
Fix merging isotopes close in mass

### DIFF
--- a/msdk-spectra/msdk-spectra-isotopepattern/src/main/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithm.java
+++ b/msdk-spectra/msdk-spectra-isotopepattern/src/main/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithm.java
@@ -151,32 +151,43 @@ public class IsotopePatternGeneratorAlgorithm {
      * intensity is added together and new m/z value is calculated as a weighted
      * average.
      */
-    private static int mergeIsotopes(double mzValues[], float intensityValues[],
-            int size, double mzTolerance) {
+    private static int mergeIsotopes(double mzValues[], float intensityValues[], int size, double mzTolerance) {
+        if (mzValues.length != intensityValues.length)
+            throw new IllegalArgumentException("Mass and intensity arrays must be of the same size");
+        if (mzValues.length < 2)
+            return mzValues.length;
 
-        int newSize = 0;
+        int ptrCur = 0;
+        int ptrNex = 1;
+        for ( ; ptrNex < mzValues.length; ptrNex++) {
+            double mzCur = mzValues[ptrCur];
+            double mzNex = mzValues[ptrNex];
+            if (Math.abs(mzCur - mzNex) < mzTolerance) {
+                // merge, only next pointer moves
+                float abCur = intensityValues[ptrCur];
+                float abNex = intensityValues[ptrNex];
+                float abNew = abCur + abNex;
+                double mzNew = (mzCur * abCur + mzNex * abNex) / abNew;
+                mzValues[ptrCur] = mzNew;
+                intensityValues[ptrCur] = abNew;
 
-        for (int i = 0; i < size; i++) {
-
-            if ((i < size - 1) && (Math
-                    .abs(mzValues[i] - mzValues[i + 1]) < mzTolerance)) {
-                float newIntensity = intensityValues[i]
-                        + intensityValues[i + 1];
-                double newMZ = (mzValues[i] * intensityValues[i]
-                        + mzValues[i + 1] * intensityValues[i + 1])
-                        / newIntensity;
-                mzValues[newSize] = newMZ;
-                intensityValues[newSize] = newIntensity;
-                mzValues[i + 1] = newMZ;
-                intensityValues[i + 1] = newIntensity;
-                i++;
             } else {
-                mzValues[newSize] = mzValues[i];
-                intensityValues[newSize] = intensityValues[i];
+                // don't merge, move current pointer and copy the value there
+                ptrCur++;
+
+                mzValues[ptrCur] = mzValues[ptrNex];
+                intensityValues[ptrCur] = intensityValues[ptrNex];
             }
-            newSize++;
         }
-        return newSize;
+
+        // ugly hack to make SimpleSpectrum not complain about masses not being sorted
+        // somewhere downstream
+        // TODO: should probably just return new arrays of proper lengths
+        for (int i = ptrCur + 1; i < mzValues.length; i++) {
+            mzValues[i] = mzValues[i - 1] + 1;
+        }
+
+        return ptrCur + 1;
 
     }
 

--- a/msdk-spectra/msdk-spectra-isotopepattern/src/main/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithm.java
+++ b/msdk-spectra/msdk-spectra-isotopepattern/src/main/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithm.java
@@ -180,13 +180,6 @@ public class IsotopePatternGeneratorAlgorithm {
             }
         }
 
-        // ugly hack to make SimpleSpectrum not complain about masses not being sorted
-        // somewhere downstream
-        // TODO: should probably just return new arrays of proper lengths
-        for (int i = ptrCur + 1; i < mzValues.length; i++) {
-            mzValues[i] = mzValues[i - 1] + 1;
-        }
-
         return ptrCur + 1;
 
     }

--- a/msdk-spectra/msdk-spectra-isotopepattern/src/test/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithmTest.java
+++ b/msdk-spectra/msdk-spectra-isotopepattern/src/test/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithmTest.java
@@ -39,7 +39,18 @@ public class IsotopePatternGeneratorAlgorithmTest {
     }
 
     @Test
-    @Ignore("Ignored due to a bug in CDK 1.5.12, waiting for new CDK version") 
+    public void testC39H60N14O14() throws MSDKException {
+        String formula = "C39H60N14O14";
+
+        MsSpectrum pattern = IsotopePatternGeneratorAlgorithm.generateIsotopes(formula, 0.01, 1.0f, 0.1);
+
+        Assert.assertEquals(new Integer(4), pattern.getNumberOfDataPoints());
+        Assert.assertEquals(1.0f, pattern.getIntensityValues()[0], 0.000001);
+        Assert.assertEquals(951.4501830990874, pattern.getMzValues()[3], 0.00001);
+    }
+
+    @Test
+    @Ignore("Ignored due to a bug in CDK 1.5.12, waiting for new CDK version")
     public void testC20H30Fe2P2S4Cl4() throws MSDKException {
 
         String formula = "C20H30Fe2P2S4Cl4";

--- a/msdk-spectra/msdk-spectra-isotopepattern/src/test/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithmTest.java
+++ b/msdk-spectra/msdk-spectra-isotopepattern/src/test/java/io/github/msdk/spectra/isotopepattern/IsotopePatternGeneratorAlgorithmTest.java
@@ -50,7 +50,6 @@ public class IsotopePatternGeneratorAlgorithmTest {
     }
 
     @Test
-    @Ignore("Ignored due to a bug in CDK 1.5.12, waiting for new CDK version")
     public void testC20H30Fe2P2S4Cl4() throws MSDKException {
 
         String formula = "C20H30Fe2P2S4Cl4";


### PR DESCRIPTION
`mergeIsotopes()` method produced strange results. When called with `mzTolerance` 0.1, for example, it would leave separate peaks that were 0.004 Da apart.

Test: `formula: C39H60N14O14`, `mz tolerance: 0.1`  

```
Old result:
mz:  948.441	 949.444	 950.444	 950.448	 951.450	
ab:    1.000	   0.473	   0.050	   0.087	   0.024

New result:
mz:  948.441	 949.444	 950.447	 951.450	
ab:    1.000	   0.473	   0.137	   0.024
```

Also had to add a hack in the end of the method to fix up remaining mass values, otherwise SimpleMsSpectrum would complain about masses not being in sorted order.