### PR TITLE
MzMLFileMemoryMapper: make class abstract and one method static

### DIFF
--- a/msdk-io/msdk-io-mzml2/src/main/java/io/github/msdk/io/mzml2/MzMLFileParser.java
+++ b/msdk-io/msdk-io-mzml2/src/main/java/io/github/msdk/io/mzml2/MzMLFileParser.java
@@ -137,8 +137,7 @@ public class MzMLFileParser implements MSDKMethod<RawDataFile> {
   public MzMLRawDataFile execute() throws MSDKException {
 
     try {
-      MzMLFileMemoryMapper mapper = new MzMLFileMemoryMapper();
-      ByteBufferInputStream is = mapper.mapToMemory(mzMLFile);
+      ByteBufferInputStream is = MzMLFileMemoryMapper.mapToMemory(mzMLFile);
 
       List<Chromatogram> chromatogramsList = new ArrayList<>();
       List<MsFunction> msFunctionsList = new ArrayList<>();
@@ -381,7 +380,7 @@ public class MzMLFileParser implements MSDKMethod<RawDataFile> {
         }
       }
       progress = 1f;
-    } catch (IOException | XMLStreamException | javax.xml.stream.XMLStreamException e) {
+    } catch (IOException | XMLStreamException e) {
       throw (new MSDKException(e));
     }
 

--- a/msdk-io/msdk-io-mzml2/src/main/java/io/github/msdk/io/mzml2/util/MzMLFileMemoryMapper.java
+++ b/msdk-io/msdk-io-mzml2/src/main/java/io/github/msdk/io/mzml2/util/MzMLFileMemoryMapper.java
@@ -18,12 +18,9 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 
-import javax.xml.stream.XMLStreamException;
-
-import io.github.msdk.MSDKException;
 import it.unimi.dsi.io.ByteBufferInputStream;
 
-public class MzMLFileMemoryMapper {
+public abstract class MzMLFileMemoryMapper {
 
   /**
    * <p>mapToMemory.</p>
@@ -31,11 +28,9 @@ public class MzMLFileMemoryMapper {
    * @param mzMLFile a {@link java.io.File} object.
    * @return a {@link it.unimi.dsi.io.ByteBufferInputStream} object.
    * @throws java.io.IOException if any.
-   * @throws javax.xml.stream.XMLStreamException if any.
    * @throws io.github.msdk.MSDKException if any.
    */
-  public ByteBufferInputStream mapToMemory(File mzMLFile)
-      throws IOException, XMLStreamException, MSDKException {
+  public static ByteBufferInputStream mapToMemory(File mzMLFile) throws IOException {
 
     RandomAccessFile aFile = new RandomAccessFile(mzMLFile, "r");
     FileChannel inChannel = aFile.getChannel();


### PR DESCRIPTION
No state is stored, so no reason to actually allocate instances to use this class.

Also minor cleanup by removing ```XMLStreamException``` and ```MSDKException``` since they aren't actually thrown by anything here.
