### PR TITLE
Hot fix the size of spectrum read by MGF import module

### DIFF
--- a/msdk-io-mgf/src/main/java/io/github/msdk/io/mgf/MgfFileImportMethod.java
+++ b/msdk-io-mgf/src/main/java/io/github/msdk/io/mgf/MgfFileImportMethod.java
@@ -155,10 +155,10 @@ public class MgfFileImportMethod implements MSDKMethod<List<MgfMsSpectrum>> {
 
 
   // Auto detect the type of spectrum and sort mz values
-    MsSpectrumType type = SpectrumTypeDetectionAlgorithm.detectSpectrumType(mz, intensity, index - 1);
-    DataPointSorter.sortDataPoints(mz, intensity, index - 1, SortingProperty.MZ, SortingDirection.ASCENDING);
+    MsSpectrumType type = SpectrumTypeDetectionAlgorithm.detectSpectrumType(mz, intensity, index);
+    DataPointSorter.sortDataPoints(mz, intensity, index, SortingProperty.MZ, SortingDirection.ASCENDING);
 
-    MgfMsSpectrum spectrum = new MgfMsSpectrum(mz, intensity, index - 1, title, precursorCharge,
+    MgfMsSpectrum spectrum = new MgfMsSpectrum(mz, intensity, index, title, precursorCharge,
         precursorMass, type);
 
     return spectrum;

--- a/msdk-io-mgf/src/test/java/io/github/msdk/io/mgf/MgfFileImportMethodTest.java
+++ b/msdk-io-mgf/src/test/java/io/github/msdk/io/mgf/MgfFileImportMethodTest.java
@@ -38,7 +38,7 @@ public class MgfFileImportMethodTest {
   public void mgfImportTest() throws IOException, MSDKException {
     final int expectedSize = 2;
     final String expectedTitle[] = {"example.9.9.2", "negative_charge"};
-    final Integer expectedNumberDatapoints[] = {18, 15};
+    final Integer expectedNumberDatapoints[] = {19, 16};
     final int[] expectedCharges = {2, -3};
     final String file = "test_query.mgf";
 
@@ -80,7 +80,7 @@ public class MgfFileImportMethodTest {
         "PRIDE_Exp_mzData_Ac_9266.xml_id_9",
         "PRIDE_Exp_mzData_Ac_9266.xml_id_10"
     };
-    final long expectedNumberDatapoints[] = {53, 66, 13, 16, 9, 9, 9, 14, 18, 13};
+    final long expectedNumberDatapoints[] = {54, 67, 14, 17, 10, 10, 10, 15, 19, 14};
     final int expectedCharges[] = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
     final String file = "F001257.mgf";
 


### PR DESCRIPTION
There was a bug that MgfSpectrum.
It used to count less m/z-intensity pairs than it was in reality. 
Because of mistake tests also did not notice it.